### PR TITLE
Cast stored message IDs to integers in fetch_old

### DIFF
--- a/fetcher/fetcher.py
+++ b/fetcher/fetcher.py
@@ -70,10 +70,12 @@ class TelegramFetcher(Fetcher):
     async def fetch_old(self):
         """Fetch the oldest messages and store them."""
         print(f"Starting to fetch oldest messages for chat {self.chat_id}...")
-        last_stored_message = min(self.storage.load_all_messages().keys(), default=None)
+        last_stored_message = min(
+            map(int, self.storage.load_all_messages().keys()), default=None
+        )
         fetch_kwargs = {"chat_id": self.chat_id, "limit": self.batch_size}
 
-        if last_stored_message:
+        if last_stored_message is not None:
             fetch_kwargs["offset_id"] = last_stored_message - 1
 
         while True:


### PR DESCRIPTION
## Summary
- Cast keys from `load_all_messages()` to integers before calculating `last_stored_message`
- Guard `offset_id` assignment with an explicit `None` check

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6895f9a39d908323b88dfb88114602b5