### PR TITLE
Add message storage status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Run `python main.py` to start the interactive shell. You can then type commands 
 - `fetch_scan`: Scans the stored message database for the current channel and reports any ranges of missing message IDs.
 - `fetch_gap <start_id> <end_id>`: Fetches all messages within the specified ID range. This is useful for filling gaps found by `fetch_scan`.
 - `list_chan`: Displays the names and IDs of all your chats and channels.
-- `status`: Shows whether a fetch operation is currently in progress.
+- `status`: Shows a summary of stored messages and any gaps detected.
 - `exit`: Exits the application.
 
 ### CLI Mode
@@ -118,6 +118,9 @@ python main.py fetch_gap 1000 2000
 
 # List available channels and chats
 python main.py list_chan
+
+# Show stored message statistics
+python main.py status
 ```
 
 ## Graceful Handling of Interruptions

--- a/fetcher/fetcher.py
+++ b/fetcher/fetcher.py
@@ -139,6 +139,25 @@ class TelegramFetcher(Fetcher):
         except Exception as e:
             print(f"Error listing channels: {e}")
 
+    def show_status(self):
+        """Display basic information about stored messages."""
+        all_messages = self.storage.load_all_messages()
+        total = len(all_messages)
+        if total == 0:
+            print("No messages stored.")
+            return
+
+        ids = list(map(int, all_messages.keys()))
+        first_id, last_id = min(ids), max(ids)
+        print(f"Stored messages: {total}")
+        print(f"ID range: {first_id} - {last_id}")
+
+        gaps = self.storage.find_gaps()
+        if gaps:
+            print(f"Gaps detected: {gaps}")
+        else:
+            print("No gaps detected.")
+
     async def _fetch_messages(self, fetch_kwargs):
         """Helper to fetch messages for better testability."""
         history = self.app.get_chat_history(**fetch_kwargs)

--- a/main.py
+++ b/main.py
@@ -24,7 +24,7 @@ def print_help():
     print("  fetch_scan (fs)  - Scan for missing messages")
     print("  fetch_gap (fg) <start_id> <end_id> - Fetch specific gap")
     print("  list_chan (lc)   - List available channels")
-    print("  status (st)      - Show status of ongoing tasks")
+    print("  status (st)      - Show stored message statistics")
     print("  exit (q, quit)   - Exit application")
 
 def parse_command(raw_cmd):


### PR DESCRIPTION
## Summary
- implement `show_status` in `TelegramFetcher` to report stored message counts, ID ranges and gaps
- expose the new status capability via CLI and update help text
- document the status command in the README with an example

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895fc5b44308323912dec16abb3951f